### PR TITLE
Tell pangeo-forge-runner what to inject

### DIFF
--- a/pangeo_forge_earthdatalogin/__init__.py
+++ b/pangeo_forge_earthdatalogin/__init__.py
@@ -33,3 +33,14 @@ class OpenURLWithEarthDataLogin(OpenURLWithFSSpec):
                 "No earthdata login credentials found - set a token with EARTHDATA_LOGIN_TOKEN environment variable, or an entry for urs.earthdata.nasa.gov in your netrc file"
             )
         return super().expand(*args, **kwargs)
+
+
+def get_injection_specs():
+    """
+    Tell pangeo-forge-runner what values to inject where
+    """
+    return {
+        "OpenURLWithEarthDataLogin": {
+            "cache": "CACHE_ROOT"
+        }
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "pangeo_forge_earthdatalogin/_version.py"
 write_to_template = "__version__ = '{version}'"
+
+[project.entry-points."pangeo_forge_runner.injection_specs"]
+edl_injections = "pangeo_forge_earthdatalogin:get_injection_specs"


### PR DESCRIPTION
Without this, this package doesn't get info about where to store caches while fetching from remote sources.

Works alongside https://github.com/pangeo-forge/pangeo-forge-runner/pull/86